### PR TITLE
Add compress() method

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+---
+Language: Cpp
+Standard: c++17
+BasedOnStyle: Google
+
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Empty
+AccessModifierOffset: -2
+TabWidth: 2
+ContinuationIndentWidth: 2
+UseTab: Never
+BreakConstructorInitializers: BeforeComma
+ColumnLimit: 100
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+DerivePointerAlignment: false
+FixNamespaceComments: true
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+IndentPPDirectives: AfterHash
+
+IncludeCategories:
+  - Regex: "^<.*/"
+    Priority: 1
+    SortPriority: 0
+  - Regex: "^<.*"
+    Priority: 2
+    SortPriority: 0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Emscripten",
+  "build": {
+    "dockerfile": "../Dockerfile"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org
+          cache: "yarn"
 
       - run: yarn install --frozen-lockfile
       - run: yarn run build

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/emsdk/upstream/emscripten/system/include",
+                "/zfp/include"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c17",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+// -*- jsonc -*-
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "xaver.clang-format",
+  ],
+  "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[cpp]": {
+    "editor.defaultFormatter": "xaver.clang-format"
+  },
+  "files.eol": "\n",
   "C_Cpp.autoAddFileAssociations": false,
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,9 @@ RUN mkdir -p /zfp && \
   git fetch --depth 1 origin release1.0.0 && \
   git checkout FETCH_HEAD
 
-WORKDIR /zfp
-
 # Build the library
-RUN mkdir -p build && \
-  cd build && \
+RUN mkdir -p /zfp/build && \
+  cd /zfp/build && \
   emcmake cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_FLAGS_RELEASE="-O3" \
@@ -24,5 +22,6 @@ RUN mkdir -p build && \
   .. && \
   emmake make
 
-COPY build.sh pre.js /zfp/
-COPY src /zfp/src
+WORKDIR /wasm-zfp
+COPY build.sh pre.js /wasm-zfp/
+COPY src /wasm-zfp/src

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Foxglove
+Copyright (c) 2022 Foxglove Technologies Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 emcc \
-  build/lib/libzfp.a -o dist/wasm-zfp.js src/wasm-zfp.c `# this runs emscripten on the code in wasm-zfp.c` \
+  /zfp/build/lib/libzfp.a -o dist/wasm-zfp.js src/wasm-zfp.c `# this runs emscripten on the code in wasm-zfp.c` \
   -O3 `# compile with all optimizations enabled` \
-  -I include `# add the zfp include directory` \
+  -I /zfp/include `# add the zfp include directory` \
   -s WASM=1 `# compile to .wasm instead of asm.js` \
   --pre-js pre.js `# include pre.js at the top of wasm-zfp.js` \
   -s MODULARIZE=1 `# include module boilerplate for better node/webpack interop` \
@@ -13,6 +13,6 @@ emcc \
   -s ALLOW_MEMORY_GROWTH=1  `# need this because we don't know how large decompressed blocks will be` \
   -s NODEJS_CATCH_EXIT=0 `# we don't use exit() and catching exit will catch all exceptions` \
   -s NODEJS_CATCH_REJECTION=0 `# prevent emscripten from adding an unhandledRejection handler` \
-  -s "EXPORTED_FUNCTIONS=['_malloc', '_free', 'getValue']" `# index.js uses Module._malloc and Module._free`
+  -s "EXPORTED_FUNCTIONS=['_malloc', '_free', 'getValue', 'setValue']" `# index.js uses Module._malloc and Module._free`
 
 cp src/index.* dist/

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -7,4 +7,4 @@ docker build . -t wasm-zfp
 
 mkdir -p dist
 
-docker run --rm -v "${SCRIPT_DIR}/dist":/zfp/dist -t wasm-zfp ./build.sh
+docker run --rm -v "${SCRIPT_DIR}/dist":/wasm-zfp/dist -t wasm-zfp ./build.sh

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "license": "MIT",
+  "author": {
+    "name": "Foxglove Technologies Inc.",
+    "email": "contact@foxglove.dev"
+  },
   "repository": "foxglove/wasm-zfp",
   "files": [
     "dist/index.d.ts",
@@ -16,8 +20,8 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "eslint": "8.30.0",
+    "eslint": "8.34.0",
     "mocha": "10.2.0",
-    "prettier": "2.8.1"
+    "prettier": "2.8.4"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,21 @@ export const enum ZfpType {
   Double = 4,
 }
 
+export type ZfpBuffer = number;
+
+export type ZfpInput = {
+  data: Int32Array | BigInt64Array | Float32Array | Float64Array;
+  shape: [number, number, number, number];
+  strides: [number, number, number, number];
+  dimensions: number;
+}
+
+export type ZfpCompressOptions = {
+  tolerance?: number;
+  rate?: number;
+  precision?: number;
+}
+
 export type ZfpResult = {
   data: Int32Array | BigInt64Array | Float32Array | Float64Array;
   dataPointer: number;
@@ -22,6 +37,7 @@ export type Zfp = {
   isLoaded: Promise<void>;
   createBuffer: () => number;
   freeBuffer: (zfpBuffer: number) => void;
+  compress: (zfpBuffer: number, input: ZfpInput, options?: ZfpCompressOptions) => ZfpResult;
   decompress: (zfpBuffer: number, src: Uint8Array) => ZfpResult;
 };
 

--- a/src/wasm-zfp.c
+++ b/src/wasm-zfp.c
@@ -1,11 +1,13 @@
-#include "zfp.h"
 #include <emscripten/emscripten.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "zfp.h"
+
 struct ZfpBuffer {
-  char *dataPointer;
+  char* dataPointer;
   size_t bufferSize;
   size_t size;
   size_t scalarSize;
@@ -15,19 +17,19 @@ struct ZfpBuffer {
   uint32_t type;
 };
 
-int main(int argc, char **argv) {}
+int main(int argc, char** argv) {}
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-struct ZfpBuffer *EMSCRIPTEN_KEEPALIVE createBuffer() {
-  struct ZfpBuffer *buffer = malloc(sizeof(struct ZfpBuffer));
+struct ZfpBuffer* EMSCRIPTEN_KEEPALIVE createBuffer() {
+  struct ZfpBuffer* buffer = malloc(sizeof(struct ZfpBuffer));
   memset(buffer, 0, sizeof(struct ZfpBuffer));
   return buffer;
 }
 
-void EMSCRIPTEN_KEEPALIVE freeBuffer(struct ZfpBuffer *buffer) {
+void EMSCRIPTEN_KEEPALIVE freeBuffer(struct ZfpBuffer* buffer) {
   if (buffer != NULL) {
     if (buffer->dataPointer != NULL) {
       free(buffer->dataPointer);
@@ -36,8 +38,88 @@ void EMSCRIPTEN_KEEPALIVE freeBuffer(struct ZfpBuffer *buffer) {
   }
 }
 
-int EMSCRIPTEN_KEEPALIVE decompress(struct ZfpBuffer *output,
-                                    const char *srcData, size_t srcLength) {
+int EMSCRIPTEN_KEEPALIVE compress(struct ZfpBuffer* output, struct ZfpBuffer* input,
+                                  float tolerance, float rate, int precision) {
+  if (input == NULL) {
+    return -1;
+  }
+  if (output == NULL) {
+    return -2;
+  }
+  if (input->dimensions < 1 || input->dimensions > 4) {
+    return -3;
+  }
+
+  // Allocate the output buffer if needed
+  if (output->dataPointer != NULL && output->bufferSize < input->size) {
+    free(output->dataPointer);
+    output->dataPointer = NULL;
+  }
+  if (output->dataPointer == NULL) {
+    output->dataPointer = malloc(input->size);
+    output->bufferSize = input->size;
+  }
+
+  // Open the output data stream
+  bitstream* outputStream = stream_open(output->dataPointer, input->size);
+  zfp_stream* zfp = zfp_stream_open(outputStream);
+
+  // Set the compression parameters
+  if (tolerance >= 0) {
+    zfp_stream_set_accuracy(zfp, tolerance);
+  } else if (rate >= 0) {
+    zfp_stream_set_rate(zfp, rate, input->type, input->dimensions, 0);
+  } else if (precision >= 0) {
+    zfp_stream_set_precision(zfp, (uint)precision);
+  } else {
+    zfp_stream_set_reversible(zfp);
+  }
+
+  // Set the field definition (header parameters)
+  zfp_field* field = zfp_field_alloc();
+  zfp_field_set_pointer(field, input->dataPointer);
+  zfp_field_set_type(field, input->type);
+  switch (input->dimensions) {
+    case 1:
+      zfp_field_set_size_1d(field, input->shape[0]);
+      zfp_field_set_stride_1d(field, input->stride[0]);
+      break;
+    case 2:
+      zfp_field_set_size_2d(field, input->shape[0], input->shape[1]);
+      zfp_field_set_stride_2d(field, input->stride[0], input->stride[1]);
+      break;
+    case 3:
+      zfp_field_set_size_3d(field, input->shape[0], input->shape[1], input->shape[2]);
+      zfp_field_set_stride_3d(field, input->stride[0], input->stride[1], input->stride[2]);
+      break;
+    case 4:
+      zfp_field_set_size_4d(field, input->shape[0], input->shape[1], input->shape[2],
+                            input->shape[3]);
+      zfp_field_set_stride_4d(field, input->stride[0], input->stride[1], input->stride[2],
+                              input->stride[3]);
+      break;
+  }
+
+  // Write the header
+  size_t bytesWritten = zfp_write_header(zfp, field, ZFP_HEADER_FULL);
+
+  // Compress the data
+  size_t compressedSize = zfp_compress(zfp, field);
+
+  // Close the streams and free allocations
+  zfp_field_free(field);
+  zfp_stream_close(zfp);
+  stream_close(outputStream);
+
+  if (compressedSize == 0) {
+    return -4;
+  }
+
+  return compressedSize;
+}
+
+int EMSCRIPTEN_KEEPALIVE decompress(struct ZfpBuffer* output, const char* srcData,
+                                    size_t srcLength) {
   if (output == NULL) {
     return -1;
   }
@@ -46,11 +128,11 @@ int EMSCRIPTEN_KEEPALIVE decompress(struct ZfpBuffer *output,
   }
 
   // Open the input data stream
-  bitstream *inputStream = stream_open((void *)srcData, srcLength);
-  zfp_stream *zfp = zfp_stream_open(inputStream);
+  bitstream* inputStream = stream_open((void*)srcData, srcLength);
+  zfp_stream* zfp = zfp_stream_open(inputStream);
 
   // Read the header
-  zfp_field *field = zfp_field_alloc();
+  zfp_field* field = zfp_field_alloc();
   size_t bytesRead = zfp_read_header(zfp, field, ZFP_HEADER_FULL);
   if (bytesRead == 0) {
     return -3;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@eslint/eslintrc@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.0.tgz#8ec64e0df3e7a1971ee1ff5158da87389f167a63"
-  integrity sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==
+"@eslint/eslintrc@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
+  integrity sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -281,12 +281,12 @@ eslint-visitor-keys@^3.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@8.30.0:
-  version "8.30.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.30.0.tgz#83a506125d089eef7c5b5910eeea824273a33f50"
-  integrity sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==
+eslint@8.34.0:
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.34.0.tgz#fe0ab0ef478104c1f9ebc5537e303d25a8fb22d6"
+  integrity sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==
   dependencies:
-    "@eslint/eslintrc" "^1.4.0"
+    "@eslint/eslintrc" "^1.4.1"
     "@humanwhocodes/config-array" "^0.11.8"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
@@ -757,10 +757,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
-  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
+prettier@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
 punycode@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
**Public-Facing Changes**
- Add `compress()` method

**Description**
Adds compression support to `wasm-zfp`. Unit tests ensure the output is identical to what the `zfp` CLI produces.
