### PR TITLE
Fix isolatedModules incompatibility, smaller compression allocations

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 100
+trailingComma: all

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,44 +1,46 @@
-export const enum ZfpType {
-  None = 0,
-  Int32 = 1,
-  Int64 = 2,
-  Float = 3,
-  Double = 4,
+declare module "wasm-zfp" {
+  export const ZfpType: {
+    INT32: 1;
+    INT64: 2;
+    FLOAT: 3;
+    DOUBLE: 4;
+  };
+
+  export type ZfpBuffer = number;
+
+  export type ZfpInput = {
+    data: Int32Array | BigInt64Array | Float32Array | Float64Array;
+    shape: [number, number, number, number];
+    strides: [number, number, number, number];
+    dimensions: number;
+  };
+
+  export type ZfpCompressOptions = {
+    tolerance?: number;
+    rate?: number;
+    precision?: number;
+  };
+
+  export type ZfpResult = {
+    data: Int32Array | BigInt64Array | Float32Array | Float64Array;
+    dataPointer: number;
+    bufferSize: number;
+    size: number;
+    scalarSize: number;
+    shape: [number, number, number, number];
+    strides: [number, number, number, number];
+    dimensions: number;
+    type: 1 | 2 | 3 | 4;
+  };
+
+  type Zfp = {
+    isLoaded: Promise<void>;
+    createBuffer: () => number;
+    freeBuffer: (zfpBuffer: number) => void;
+    compress: (zfpBuffer: number, input: ZfpInput, options?: ZfpCompressOptions) => ZfpResult;
+    decompress: (zfpBuffer: number, src: Uint8Array) => ZfpResult;
+  };
+
+  const zfp: Zfp;
+  export default zfp;
 }
-
-export type ZfpBuffer = number;
-
-export type ZfpInput = {
-  data: Int32Array | BigInt64Array | Float32Array | Float64Array;
-  shape: [number, number, number, number];
-  strides: [number, number, number, number];
-  dimensions: number;
-}
-
-export type ZfpCompressOptions = {
-  tolerance?: number;
-  rate?: number;
-  precision?: number;
-}
-
-export type ZfpResult = {
-  data: Int32Array | BigInt64Array | Float32Array | Float64Array;
-  dataPointer: number;
-  bufferSize: number;
-  size: number;
-  scalarSize: number;
-  shape: [number, number, number, number];
-  strides: [number, number, number, number];
-  dimensions: number;
-  type: ZfpType;
-};
-
-export type Zfp = {
-  isLoaded: Promise<void>;
-  createBuffer: () => number;
-  freeBuffer: (zfpBuffer: number) => void;
-  compress: (zfpBuffer: number, input: ZfpInput, options?: ZfpCompressOptions) => ZfpResult;
-  decompress: (zfpBuffer: number, src: Uint8Array) => ZfpResult;
-};
-
-export default Zfp;

--- a/test/index.js
+++ b/test/index.js
@@ -2,8 +2,6 @@ process.env.NODE_ENV = "test";
 
 const fs = require("fs");
 const assert = require("assert");
-
-/** @type { import("..").Zfp } */
 const Zfp = require("../");
 
 // uncompressed.raw is a 2x3x4 array of float32s
@@ -146,6 +144,28 @@ describe("compression", () => {
     Zfp.freeBuffer(zfpBuffer);
   });
 
+  it("compresses vec3f without explicit strides", () => {
+    const zfpBuffer = Zfp.createBuffer();
+    // `zfp -i uncompressed.raw -h -f -3 2 3 4 -a 1 -z compressed.zfp`
+    const zfpInput = {
+      data: float32s,
+      shape: [2, 3, 4, 0],
+      dimensions: 3,
+    };
+    const output = Zfp.compress(zfpBuffer, zfpInput, { tolerance: 1 });
+
+    // Compare byte-for-byte with `compressed`
+    assert(output.byteLength === compressed.byteLength)
+    for (var i = 0; i < output.byteLength; i++) {
+      assert(
+        output[i] === compressed[i],
+        `${i}: ${output[i]} !== ${compressed[i]}`
+      );
+    }
+
+    Zfp.freeBuffer(zfpBuffer);
+  });
+
   it("compresses vec3i64", () => {
     const zfpBuffer = Zfp.createBuffer();
     // `zfp -i uncompressedi64.raw -h -t i64 -1 10 -R -z compressedi64.zfp`
@@ -173,8 +193,8 @@ describe("compression", () => {
     const zfpBuffer = Zfp.createBuffer();
     const zfpInput = {
       data: float32s,
-      shape: [2, 3, 4],
-      strides: [1, 2, 6],
+      shape: [2, 3, 4, 0],
+      strides: [1, 2, 6, 0],
       dimensions: 3,
     };
     Zfp.compress(zfpBuffer, zfpInput);


### PR DESCRIPTION
**Public-Facing Changes**
- Fixed incompatibility with TypeScript `isolatedModules` setting
- Reduced WASM heap allocation size during decompression
